### PR TITLE
no axapi mapping for mprescripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -351,8 +351,7 @@
 		    <span class="objattr">Object Attribute: <code>tag:mprescripts</code></span>
 		  </td>
 		  <td class="axapi">
-		    <span class="role">AXRole: <code>NSAccessibilityGroupRole</code></span><br />
-		    <span class="subrole">AXSubrole: <code>AXMathMultiscript</code></span>
+		  	Not mapped
 		  </td>
 		</tr>
 		<tr id="el-mroot">


### PR DESCRIPTION
mprescripts is a delimiter between postscripts and prescripts, which are exposed via AXMathPrescripts and AXMathPostcripts attributes, and thus doesn't provide any useful semantics on mac