### PR TITLE
Update AXMathRootRadicand to return of list of children

### DIFF
--- a/index.html
+++ b/index.html
@@ -383,7 +383,7 @@
 		    <span class="role">AXRole: <code>NSAccessibilityGroupRole</code></span><br />
 		    <span class="subrole">AXSubrole: <code>AXMathRoot</code></span><br />
 		    <span class="attrs">AXAttributes:
-		      <code>AXMathRootRadicand</code> pointing to the first in-flow child<br />
+		      <code>AXMathRootRadicand</code> is an array containing the first in-flow child as its unique element,<br />
 		      <code>AXMathRootIndex</code> pointing to the second in-flow child
 		    </span>
 		  </td>
@@ -433,7 +433,7 @@
 		    <span class="role">AXRole: <code>NSAccessibilityGroupRole</code></span><br />
 		    <span class="subrole">AXSubrole: <code>AXMathSquareRoot</code></span><br />
 		    <span class="attrs">AXAttributes:
-		      <code>AXMathRootRadicand</code> pointing to the first in-flow child
+		      <code>AXMathRootRadicand</code> is an array containing the in-flow children
 		    </span>
 		  </td>
 		</tr>


### PR DESCRIPTION
This is what is being implemented for `<mroot>` and `<msqrt>`.

closes https://github.com/w3c/mathml-aam/issues/4


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fred-wang/mathml-aam/pull/18.html" title="Last updated on Oct 11, 2021, 8:40 AM UTC (4249bb7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mathml-aam/18/966f188...fred-wang:4249bb7.html" title="Last updated on Oct 11, 2021, 8:40 AM UTC (4249bb7)">Diff</a>