### PR TITLE
Add ATK and AX API mapping for <mphantom>

### DIFF
--- a/index.html
+++ b/index.html
@@ -382,6 +382,20 @@
 		    <span class="subrole">AXSubrole: <code>TBD</code></span>
 		  </td>
 		</tr>
+		<tr id="el-phantom">
+		  <th><a data-cite="MathML3/chapter3.html#presm.mphantom">`mphantom`</a></th>
+		  <td class="aria">No corresponding role</td>
+		  <td class="ia2">TBD</td>
+		  <td class="uia">TBD</td>
+		  <td class="atk">
+		    <span class="role">Role: <code>ATK_ROLE_SECTION</code></span><br />
+		    <span class="objattr">Object Attribute: <code>tag:mphantom</code></span>
+		  </td>
+		  <td class="axapi">
+		    <span class="role">AXRole: <code>NSAccessibilityGroupRole</code></span><br />
+		    <span class="subrole">AXSubrole: <code>AXMathRow</code></span>
+		  </td>
+		</tr>
 		<tr id="el-mprescripts">
 		  <th><a data-cite="MathML3/chapter3.html#presm.mmultiscripts">`mprescripts`</a></th>
 		  <td class="aria">No corresponding role</td>


### PR DESCRIPTION
See discussion in [1]. Per MathML Core [2], `<mphantom>` has style
    `visibility: hidden` by default and so is not exposed to ATs [3].
    This commit specifies how to map `<mphantom>` when the element is
    exposed (e.g. by reverting `visibility: hidden`), essentially
    following what exists for the `<mrow>` element.
    
    [1] https://github.com/w3c/mathml-aam/issues/9
    [2] https://w3c.github.io/mathml-core/#making-sub-expressions-invisible-mphantom
    [3] https://www.w3.org/TR/wai-aria-1.2/#tree_exclusion


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fred-wang/mathml-aam/pull/20.html" title="Last updated on Aug 29, 2023, 8:30 AM UTC (06223fa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mathml-aam/20/9698ad7...fred-wang:06223fa.html" title="Last updated on Aug 29, 2023, 8:30 AM UTC (06223fa)">Diff</a>