### PR TITLE
Copy mapping of the <math> tag from HTML AAM

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,6 +191,7 @@
 		  <th><abbr title="User Interface Automation">UIA</abbr></th>
 		  <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
 		  <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                  <th>[[wai-aria-1.1]]</th>
 		</tr>
 	      </thead>
               <tbody>
@@ -233,6 +234,16 @@
 		    <span class="subrole">AXSubrole: <code>TBD</code></span>
 		  </td>
 		</tr>
+                <tr id="el-math">
+                  <th>
+                    <a data-cite="html/embedded-content-other.html#mathml">`math`</a>
+                  </th>
+                  <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+                  <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+                  <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+                  <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+                  <td class="aria"><a class="core-mapping" href="#role-map-math">`math`</a> role</td>
+                </tr>
 		<tr id="el-merror">
 		  <th><a data-cite="MathML3/chapter3.html#presm.merror">`merror`</a></th>
 		  <td class="ia2">TBD</td>

--- a/index.html
+++ b/index.html
@@ -234,16 +234,16 @@
 		    <span class="subrole">AXSubrole: <code>TBD</code></span>
 		  </td>
 		</tr>
-                <tr id="el-math">
-                  <th>
-                    <a data-cite="html/embedded-content-other.html#mathml">`math`</a>
-                  </th>
-                  <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                  <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                  <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                  <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                  <td class="aria"><a class="core-mapping" href="#role-map-math">`math`</a> role</td>
-                </tr>
+		<tr id="el-math">
+		  <th>
+		    <a data-cite="html/embedded-content-other.html#mathml">`math`</a>
+		  </th>
+		  <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+		  <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+		  <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+		  <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+		  <td class="aria"><a class="core-mapping" href="#role-map-math">`math`</a> role</td>
+		</tr>
 		<tr id="el-merror">
 		  <th><a data-cite="MathML3/chapter3.html#presm.merror">`merror`</a></th>
 		  <td class="ia2">TBD</td>

--- a/index.html
+++ b/index.html
@@ -54,6 +54,15 @@
 	      "REC": "https://www.w3.org/TR/wai-aria/"
 	  },
 
+          // ED pointing to latest draft due to ED links not
+          // appropriately mapping on the core-aam spec.
+          coreMappingURLs: {
+              "ED":   "https://w3c.github.io/core-aam/",
+              "WD":   "https://www.w3.org/TR/core-aam-1.1/",
+              "FPWD": "https://www.w3.org/TR/core-aam-1.1/",
+              "REC":  "https://www.w3.org/TR/wai-aria-implementation/"
+          },
+
 	  preProcess: [ linkCrossReferences ]
       };
     </script>


### PR DESCRIPTION
This commit copies the mapping described in the HTML AAM spec for the
`<math>` element. This will allow the HTML AAM spec to directly refer to
the mapping from the MathML AAM spec. See [1] and [2].

[1] https://github.com/w3c/mathml-aam/issues/9
[2] https://github.com/w3c/html-aam/issues/344


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fred-wang/mathml-aam/pull/21.html" title="Last updated on Nov 4, 2021, 10:48 AM UTC (1306831)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mathml-aam/21/ec03110...fred-wang:1306831.html" title="Last updated on Nov 4, 2021, 10:48 AM UTC (1306831)">Diff</a>