### PR TITLE
Migrate from deprecated respec-w3c-common to respec-w3c

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>MathML Accessiblity API Mappings 1.0</title>
     <script src="https://www.w3.org/scripts/jquery/1.11.3/jquery.min.js"></script>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove" defer="defer"></script>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
     <script src="common/script/resolveReferences.js" class="remove"></script>
     <script src="common/biblio.js" class="remove" defer="defer"></script>
 
@@ -23,10 +23,8 @@
 	  github: "w3c/mathml-aam",
 	  copyrightStart:  "2020",
 
-	  wg: "Accessible Rich Internet Applications Working Group",
-	  wgURI: "https://www.w3.org/WAI/ARIA/",
+	  group: "aria",
 	  wgPublicList: "public-aria",
-	  wgPatentURI: "https://www.w3.org/2004/01/pp-impl/83726/status",
 
 	  editors:  [
               { name: "Joanmarie Diggs",

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>MathML Accessiblity API Mappings 1.0</title>
     <script src="https://www.w3.org/scripts/jquery/1.11.3/jquery.min.js"></script>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer"></script>
     <script src="common/script/resolveReferences.js" class="remove"></script>
     <script src="common/biblio.js" class="remove" defer="defer"></script>
 


### PR DESCRIPTION
See
https://github.com/w3c/respec/wiki/respec-w3c-common-migration-guide

Other references:
https://respec.org/w3c/groups/
https://respec.org/docs/#wg
https://respec.org/docs/#wgPatentURI
https://respec.org/docs/#wgURI


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fred-wang/mathml-aam/pull/22.html" title="Last updated on Nov 5, 2021, 6:41 AM UTC (2fdf96f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mathml-aam/22/c25e26b...fred-wang:2fdf96f.html" title="Last updated on Nov 5, 2021, 6:41 AM UTC (2fdf96f)">Diff</a>