### PR TITLE
Align presentation of ARIA role mapping with HTML AAM

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,16 +196,17 @@
 	      <thead>
 		<tr>
 		  <th>Element</th>
+		  <th>[[wai-aria-1.1]]</th>
 		  <th>MSAA + IAccessible2</th>
 		  <th><abbr title="User Interface Automation">UIA</abbr></th>
 		  <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
 		  <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-                  <th>[[wai-aria-1.1]]</th>
 		</tr>
 	      </thead>
               <tbody>
 		<tr id="el-annotation">
 		  <th><a data-cite="MathML3/chapter5.html#mixing.elements.annotation">`annotation`</a></th>
+		  <td class="aria">No corresponding role</td>
 		  <td class="ia2">TBD</td>
 		  <td class="uia">TBD</td>
 		  <td class="atk">
@@ -219,6 +220,7 @@
 		</tr>
 		<tr id="el-annotation-xml">
 		  <th><a data-cite="MathML3/chapter5.html#mixing.elements.annotation.xml">`annotation-xml`</a></th>
+		  <td class="aria">No corresponding role</td>
 		  <td class="ia2">TBD</td>
 		  <td class="uia">TBD</td>
 		  <td class="atk">
@@ -232,6 +234,7 @@
 		</tr>
 		<tr id="el-maction">
 		  <th><a data-cite="MathML3/chapter3.html#presm.maction">`maction`</a></th>
+		  <td class="aria">No corresponding role</td>
 		  <td class="ia2">TBD</td>
 		  <td class="uia">TBD</td>
 		  <td class="atk">
@@ -247,14 +250,15 @@
 		  <th>
 		    <a data-cite="html/embedded-content-other.html#mathml">`math`</a>
 		  </th>
+		  <td class="aria"><a class="core-mapping" href="#role-map-math">`math`</a> role</td>
 		  <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
 		  <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
 		  <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
 		  <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-		  <td class="aria"><a class="core-mapping" href="#role-map-math">`math`</a> role</td>
 		</tr>
 		<tr id="el-merror">
 		  <th><a data-cite="MathML3/chapter3.html#presm.merror">`merror`</a></th>
+		  <td class="aria">No corresponding role</td>
 		  <td class="ia2">TBD</td>
 		  <td class="uia">TBD</td>
 		  <td class="atk">
@@ -268,6 +272,7 @@
 		</tr>
 		<tr id="el-mfrac">
 		  <th><a data-cite="MathML3/chapter3.html#presm.mfrac">`mfrac`</a></th>
+		  <td class="aria">No corresponding role</td>
 		  <td class="ia2">TBD</td>
 		  <td class="uia">TBD</td>
 		  <td class="atk">
@@ -285,6 +290,7 @@
 		</tr>
 		<tr id="el-mi">
 		  <th><a data-cite="MathML3/chapter3.html#presm.mi">`mi`</a></th>
+		  <td class="aria">No corresponding role</td>
 		  <td class="ia2">TBD</td>
 		  <td class="uia">TBD</td>
 		  <td class="atk">
@@ -298,6 +304,7 @@
 		</tr>
 		<tr id="el-mmultiscripts">
 		  <th><a data-cite="MathML3/chapter3.html#presm.mmultiscripts">`mmultiscripts`</a></th>
+		  <td class="aria">No corresponding role</td>
 		  <td class="ia2">TBD</td>
 		  <td class="uia">TBD</td>
 		  <td class="atk">
@@ -325,6 +332,7 @@
 		</tr>
 		<tr id="el-mn">
 		  <th><a data-cite="MathML3/chapter3.html#presm.mn">`mn`</a></th>
+		  <td class="aria">No corresponding role</td>
 		  <td class="ia2">TBD</td>
 		  <td class="uia">TBD</td>
 		  <td class="atk">
@@ -338,6 +346,7 @@
 		</tr>
 		<tr id="el-mo">
 		  <th><a data-cite="MathML3/chapter3.html#presm.mo">`mo`</a></th>
+		  <td class="aria">No corresponding role</td>
 		  <td class="ia2">TBD</td>
 		  <td class="uia">TBD</td>
 		  <td class="atk">
@@ -351,6 +360,7 @@
 		</tr>
 		<tr id="el-mover">
 		  <th><a data-cite="MathML3/chapter3.html#presm.mover">`mover`</a></th>
+		  <td class="aria">No corresponding role</td>
 		  <td class="ia2">TBD</td>
 		  <td class="uia">TBD</td>
 		  <td class="atk">
@@ -368,6 +378,7 @@
 		</tr>
 		<tr id="el-mpadded">
 		  <th><a data-cite="MathML3/chapter3.html#presm.mpadded">`mpadded`</a></th>
+		  <td class="aria">No corresponding role</td>
 		  <td class="ia2">TBD</td>
 		  <td class="uia">TBD</td>
 		  <td class="atk">
@@ -381,6 +392,7 @@
 		</tr>
 		<tr id="el-mprescripts">
 		  <th><a data-cite="MathML3/chapter3.html#presm.mmultiscripts">`mprescripts`</a></th>
+		  <td class="aria">No corresponding role</td>
 		  <td class="ia2">TBD</td>
 		  <td class="uia">TBD</td>
 		  <td class="atk">
@@ -393,6 +405,7 @@
 		</tr>
 		<tr id="el-mroot">
 		  <th><a data-cite="MathML3/chapter3.html#presm.mroot">`mroot`</a></th>
+		  <td class="aria">No corresponding role</td>
 		  <td class="ia2">TBD</td>
 		  <td class="uia">TBD</td>
 		  <td class="atk">
@@ -410,6 +423,7 @@
 		</tr>
 		<tr id="el-mrow">
 		  <th><a data-cite="MathML3/chapter3.html#presm.mrow">`mrow`</a></th>
+		  <td class="aria">No corresponding role</td>
 		  <td class="ia2">TBD</td>
 		  <td class="uia">TBD</td>
 		  <td class="atk">
@@ -423,6 +437,7 @@
 		</tr>
 		<tr id="el-ms">
 		  <th><a data-cite="MathML3/chapter3.html#presm.ms">`ms`</a></th>
+		  <td class="aria">No corresponding role</td>
 		  <td class="ia2">TBD</td>
 		  <td class="uia">TBD</td>
 		  <td class="atk">
@@ -436,6 +451,7 @@
 		</tr>
 		<tr id="el-mspace">
 		  <th><a data-cite="MathML3/chapter3.html#presm.mspace">`mspace`</a></th>
+		  <td class="aria">No corresponding role</td>
 		  <td class="ia2">TBD</td>
 		  <td class="uia">TBD</td>
 		  <td class="atk">Not mapped</td>
@@ -443,6 +459,7 @@
 		</tr>
 		<tr id="el-msqrt">
 		  <th><a data-cite="MathML3/chapter3.html#presm.mroot">`msqrt`</a></th>
+		  <td class="aria">No corresponding role</td>
 		  <td class="ia2">TBD</td>
 		  <td class="uia">TBD</td>
 		  <td class="atk">
@@ -459,6 +476,7 @@
 		</tr>
 		<tr id="el-mstyle">
 		  <th><a data-cite="MathML3/chapter3.html#presm.mstyle">`mstyle`</a></th>
+		  <td class="aria">No corresponding role</td>
 		  <td class="ia2">TBD</td>
 		  <td class="uia">TBD</td>
 		  <td class="atk">
@@ -472,6 +490,7 @@
 		</tr>
 		<tr id="el-msub">
 		  <th><a data-cite="MathML3/chapter3.html#presm.msub">`msub`</a></th>
+		  <td class="aria">No corresponding role</td>
 		  <td class="ia2">TBD</td>
 		  <td class="uia">TBD</td>
 		  <td class="atk">
@@ -490,6 +509,7 @@
 		</tr>
 		<tr id="el-msubsup">
 		  <th><a data-cite="MathML3/chapter3.html#presm.msubsup">`msubsup`</a></th>
+		  <td class="aria">No corresponding role</td>
 		  <td class="ia2">TBD</td>
 		  <td class="uia">TBD</td>
 		  <td class="atk">
@@ -509,6 +529,7 @@
 		</tr>
 		<tr id="el-msup">
 		  <th><a data-cite="MathML3/chapter3.html#presm.msup">`msup`</a></th>
+		  <td class="aria">No corresponding role</td>
 		  <td class="ia2">TBD</td>
 		  <td class="uia">TBD</td>
 		  <td class="atk">
@@ -526,6 +547,7 @@
 		</tr>
 		<tr id="el-mtable">
 		  <th><a data-cite="MathML3/chapter3.html#presm.mtable">`mtable`</a></th>
+		  <td class="aria">No corresponding role</td>
 		  <td class="ia2">TBD</td>
 		  <td class="uia">TBD</td>
 		  <td class="atk">
@@ -540,6 +562,7 @@
 		</tr>
 		<tr id="el-mtd">
 		  <th><a data-cite="MathML3/chapter3.html#presm.mtd">`mtd`</a></th>
+		  <td class="aria">No corresponding role</td>
 		  <td class="ia2">TBD</td>
 		  <td class="uia">TBD</td>
 		  <td class="atk">
@@ -554,6 +577,7 @@
 		</tr>
 		<tr id="el-mtext">
 		  <th><a data-cite="MathML3/chapter3.html#presm.mtext">`mtext`</a></th>
+		  <td class="aria">No corresponding role</td>
 		  <td class="ia2">TBD</td>
 		  <td class="uia">TBD</td>
 		  <td class="atk">
@@ -567,6 +591,7 @@
 		</tr>
 		<tr id="el-mtr">
 		  <th><a data-cite="MathML3/chapter3.html#presm.mtr">`mtr`</a></th>
+		  <td class="aria">No corresponding role</td>
 		  <td class="ia2">TBD</td>
 		  <td class="uia">TBD</td>
 		  <td class="atk">
@@ -580,6 +605,7 @@
 		</tr>
 		<tr id="el-munder">
 		  <th><a data-cite="MathML3/chapter3.html#presm.munder">`munder`</a></th>
+		  <td class="aria">No corresponding role</td>
 		  <td class="ia2">TBD</td>
 		  <td class="uia">TBD</td>
 		  <td class="atk">
@@ -597,6 +623,7 @@
 		</tr>
 		<tr id="el-munderover">
 		  <th><a data-cite="MathML3/chapter3.html#presm.munderover">`munderover`</a></th>
+		  <td class="aria">No corresponding role</td>
 		  <td class="ia2">TBD</td>
 		  <td class="uia">TBD</td>
 		  <td class="atk">
@@ -615,6 +642,7 @@
 		</tr>
 		<tr id="el-none">
 		  <th><a data-cite="MathML3/chapter3.html#presm.mmultiscripts">`none`</a></th>
+		  <td class="aria">No corresponding role</td>
 		  <td class="ia2">TBD</td>
 		  <td class="uia">TBD</td>
 		  <td class="atk">
@@ -628,6 +656,7 @@
 		</tr>
 		<tr id="el-semantics">
 		  <th><a data-cite="MathML3/chapter3.html#presm.semantics">`semantics`</a></th>
+		  <td class="aria">No corresponding role</td>
 		  <td class="ia2">TBD</td>
 		  <td class="uia">TBD</td>
 		  <td class="atk">


### PR DESCRIPTION
This commit performs the following, for consistency with HTML AAM:
- Move the [wai-aria-1.1] rows at the top.
- Explicitly state "No corresponding role".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fred-wang/mathml-aam/pull/24.html" title="Last updated on Nov 5, 2021, 7:23 AM UTC (2f40b74)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mathml-aam/24/c25e26b...fred-wang:2f40b74.html" title="Last updated on Nov 5, 2021, 7:23 AM UTC (2f40b74)">Diff</a>